### PR TITLE
Order labels by cardinality (and show its count)

### DIFF
--- a/cmd/cardinality.go
+++ b/cmd/cardinality.go
@@ -43,11 +43,11 @@ type seriesTable struct {
 func newModel(sm map[string]scrape.SeriesSet, height int) *seriesTable {
 	tbl := table.New(
 		table.WithColumns([]table.Column{
-			{Title: "Name", Width: 80},
+			{Title: "Name", Width: 60},
 			{Title: "Cardinality", Width: 16},
 			{Title: "Type", Width: 10},
 			{Title: "Labels", Width: 80},
-			{Title: "Created TS", Width: 40},
+			{Title: "Created TS", Width: 50},
 		}),
 		table.WithFocused(true),
 		table.WithHeight(height),

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,17 @@ module github.com/pedro-stanaka/prom-scrape-analyzer
 go 1.23.1
 
 require (
+	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
 	github.com/charmbracelet/bubbles v0.20.0
+	github.com/charmbracelet/bubbletea v1.1.0
+	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/go-kit/log v0.2.1
 	github.com/oklog/run v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/prometheus v0.52.2-0.20240614130246-4c1e71fa0b3d
+	github.com/stretchr/testify v1.9.0
 	github.com/thanos-io/thanos v0.36.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
@@ -20,16 +24,14 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 // indirect
 	github.com/aws/aws-sdk-go v1.53.16 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/bubbletea v1.1.0 // indirect
-	github.com/charmbracelet/lipgloss v0.13.0 // indirect
 	github.com/charmbracelet/x/ansi v0.2.3 // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/efficientgo/tools/extkingpin v0.0.0-20220817170617-6c25e3b627dd // indirect
@@ -59,6 +61,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.54.1-0.20240615204547-04635d2962f9 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
@@ -90,6 +93,7 @@ require (
 	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.29.3 // indirect
 	k8s.io/client-go v0.29.3 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect

--- a/pkg/scrape/series_test.go
+++ b/pkg/scrape/series_test.go
@@ -1,0 +1,68 @@
+package scrape_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pedro-stanaka/prom-scrape-analyzer/pkg/scrape"
+)
+
+func TestSeriesSet_Cardinality(t *testing.T) {
+	seriesSet := scrape.SeriesSet{
+		1: {Name: "series1"},
+		2: {Name: "series2"},
+	}
+
+	expected := 2
+	require.Equal(t, expected, seriesSet.Cardinality(), "Cardinality() should return the correct number of series")
+}
+
+func TestSeriesSet_MetricTypeString(t *testing.T) {
+	seriesSet := scrape.SeriesSet{
+		1: {Name: "series1", Type: "gauge"},
+		2: {Name: "series2", Type: "counter"},
+	}
+
+	expected := "gauge|counter"
+	require.Equal(t, expected, seriesSet.MetricTypeString(), "MetricTypeString() should return the correct metric types")
+}
+
+func TestSeriesSet_CreatedTS(t *testing.T) {
+	seriesSet := scrape.SeriesSet{
+		1: {Name: "series1", CreatedTimestamp: 1620000000},
+		2: {Name: "series2", CreatedTimestamp: 1620000001},
+	}
+
+	expected := int64(1620000000)
+	require.Equal(t, expected, seriesSet.CreatedTS(), "CreatedTS() should return the correct created timestamp")
+}
+
+func TestSeriesSet_LabelNames(t *testing.T) {
+	seriesSet := scrape.SeriesSet{
+		1: {Name: "series1", Labels: labels.Labels{{Name: "label1"}, {Name: "label2"}}},
+		2: {Name: "series2", Labels: labels.Labels{{Name: "label2"}, {Name: "label3"}}},
+	}
+
+	expected := "label1|label2|label3"
+	require.Equal(t, expected, seriesSet.LabelNames(), "LabelNames() should return the correct label names")
+}
+
+func TestSeriesSet_LabelStats(t *testing.T) {
+	seriesSet := scrape.SeriesSet{
+		1: {Name: "series1", Labels: labels.Labels{{Name: "label1", Value: "foo"}, {Name: "label2", Value: "bar"}}},
+		2: {Name: "series2", Labels: labels.Labels{{Name: "label2", Value: "baz"}, {Name: "label3", Value: "qux"}}},
+		3: {Name: "series3", Labels: labels.Labels{{Name: "label2", Value: "baz"}, {Name: "label3", Value: "qua"}}},
+	}
+
+	expected := scrape.LabelStatsSlice{
+		{Name: "label1", DistinctValues: 1},
+		{Name: "label2", DistinctValues: 2},
+		{Name: "label3", DistinctValues: 2},
+	}
+	got := seriesSet.LabelStats()
+
+	require.Len(t, got, len(expected), "LabelStats() should return the correct number of label stats")
+	require.EqualValues(t, expected, got, "LabelStats() should return the correct label stats")
+}


### PR DESCRIPTION
Updates the analyzer to order labels by cardinality and show its count in the `seriesTable`.

Closes #10 
