### PR TITLE
fix: panic when no metrics and you try to open in EDITOR

### DIFF
--- a/cmd/cardinality.go
+++ b/cmd/cardinality.go
@@ -262,6 +262,10 @@ func (m *seriesTable) updateWhileBrowsingTable(msg tea.Msg) (tea.Model, tea.Cmd)
 			return m, cmd
 		case "enter", "v":
 			selectedRow := m.table.SelectedRow()
+			if len(selectedRow) == 0 {
+				return m, m.flashMsg.Flash("No series available to open", internal.Error, flashDuration)
+			}
+
 			metricName := selectedRow[0]
 			seriesText := m.seriesScrapeText[metricName]
 


### PR DESCRIPTION
While it clearly doesn't make sense to attempt to open something that
doesn't exist, an accidental extra press of "Enter" after inputting some
search text that returns no results shouldn't cause the whole program to
panic, either ;)

To reproduce:
1. run node_exporter
2. run analyzer: `./prom-scrape-analyzer-linux-amd64 cardinality --scrape-url http://localhost:9100/metrics`
3. run a search that returns no results (ie: press `/`, type `foo` and
   `enter` to run search)
4. press enter again, just cuz.
5. panic

Example:
```
~/go/src/github.com/pedro-stanaka/prom-scrape-analyzer (main [  ]) -> ./prom-scrape-analyzer-linux-amd64 cardinality --scrape-url http://localhost:9100/metrics
ts=2025-02-01T05:17:08.212986803Z caller=cardinality.go:420 level=info msg=scraping url=http://localhost:9100/metrics timeout=10s max_size=100000000
⢿
┌─────┐
│> foo│
└─────┘
<...snip blank table...>
↑/k up • ↓/j down • / search metrics • v/↵ view series in text editor
Caught panic:

runtime error: index out of range [0] with length 0

Restoring terminal...

goroutine 38 [running]:
runtime/debug.Stack()
        /home/tjhop/.asdf/installs/golang/1.23.5/go/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
        /home/tjhop/.asdf/installs/golang/1.23.5/go/src/runtime/debug/stack.go:18 +0x13
github.com/charmbracelet/bubbletea.(*Program).Run.func1()
        /home/tjhop/.asdf/installs/golang/1.23.5/packages/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.0/tea.go:519 +0x8b
panic({0xdc54a0?, 0xc0004a0000?})
        /home/tjhop/.asdf/installs/golang/1.23.5/go/src/runtime/panic.go:785 +0x132
main.(*seriesTable).updateWhileBrowsingTable(0xc000154008, {0xdb8620, 0xc000a193f8})
        /home/tjhop/go/src/github.com/pedro-stanaka/prom-scrape-analyzer/cmd/cardinality.go:265 +0xd68
main.(*seriesTable).updateWhileSearchingMetrics(0xc000154008, {0xdb8620, 0xc000888000})
        /home/tjhop/go/src/github.com/pedro-stanaka/prom-scrape-analyzer/cmd/cardinality.go:326 +0x2ad
main.(*seriesTable).Update(0xc000154008?, {0xdb8620?, 0xc000888000?})
        /home/tjhop/go/src/github.com/pedro-stanaka/prom-scrape-analyzer/cmd/cardinality.go:236 +0x4f6
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0xc0005b3560, {0x1082670?, 0xc000154008?}, 0xc0005d60e0)
        /home/tjhop/.asdf/installs/golang/1.23.5/packages/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.0/tea.go:452 +0x810
github.com/charmbracelet/bubbletea.(*Program).Run(0xc0005b3560)
        /home/tjhop/.asdf/installs/golang/1.23.5/packages/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.0/tea.go:593 +0xa32
main.registerCardinalityCommand.func1.1()
        /home/tjhop/go/src/github.com/pedro-stanaka/prom-scrape-analyzer/cmd/cardinality.go:406 +0x17
github.com/oklog/run.(*Group).Run.func1({0xc0005984d0?, 0xc0005984e0?})
        /home/tjhop/.asdf/installs/golang/1.23.5/packages/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38 +0x29
created by github.com/oklog/run.(*Group).Run in goroutine 1
        /home/tjhop/.asdf/installs/golang/1.23.5/packages/pkg/mod/github.com/oklog/run@v1.1.0/group.go:37 +0x5a
ts=2025-02-01T05:17:17.193638938Z caller=main.go:88 level=info msg=exiting
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
