### PR TITLE
feat: HTTP config file support for basic auth and TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ for creating an intuitive and interactive command-line interface.
 - [x] Support for latest features like Created Timestamps and Native Histograms, showing them as separate columns.
 - [x] Allow to select a specific metric to inspect, and show its series.
 - [x] Metric search with fuzzy search.
+- [x] [HTTP configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config) to support custom HTTP client options like basic auth, custom headers, proxy configs, etc.
 
 ## Planned Features
 

--- a/cmd/cardinality.go
+++ b/cmd/cardinality.go
@@ -398,6 +398,7 @@ func registerCardinalityCommand(app *extkingpin.App) {
 	) error {
 		scrapeURL := opts.ScrapeURL
 		timeoutDuration := opts.Timeout
+		httpConfigFile := opts.HttpConfigFile
 
 		metricTable := newModel(nil, opts.OutputHeight, logger)
 		p := tea.NewProgram(metricTable)
@@ -426,6 +427,7 @@ func registerCardinalityCommand(app *extkingpin.App) {
 				"url", scrapeURL,
 				"timeout", timeoutDuration,
 				"max_size", maxSize,
+				"http_config_file", httpConfigFile,
 			)
 
 			t0 := time.Now()
@@ -434,6 +436,7 @@ func registerCardinalityCommand(app *extkingpin.App) {
 				logger,
 				scrape.WithTimeout(timeoutDuration),
 				scrape.WithMaxBodySize(maxSize),
+				scrape.WithHttpConfigFile(httpConfigFile),
 			)
 			metrics, err := scraper.Scrape()
 			if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	metrics := prometheus.NewRegistry()
 	metrics.MustRegister(
-		versioncollector.NewCollector("thanos"),
+		versioncollector.NewCollector("prom_scrape_analyzer"),
 		collectors.NewGoCollector(
 			collectors.WithGoCollectorRuntimeMetrics(collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile("/.*")}),
 		),

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Options struct {
-	ScrapeURL     string
-	OutputHeight  int
-	MaxScrapeSize string
-	Timeout       time.Duration
+	ScrapeURL      string
+	OutputHeight   int
+	MaxScrapeSize  string
+	Timeout        time.Duration
+	HttpConfigFile string
 }
 
 func (o *Options) MaxScrapeSizeBytes() (int64, error) {
@@ -39,4 +40,8 @@ func (o *Options) AddFlags(app extkingpin.AppClause) {
 	app.Flag("max-scrape-size", "Maximum size of the scrape response body (e.g. 10MB, 1GB)").
 		Default("100MB").
 		StringVar(&o.MaxScrapeSize)
+
+	app.Flag("http.config", "Path to file to use for HTTP client config options like basic auth and TLS.").
+		Default("").
+		StringVar(&o.HttpConfigFile)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
+	github.com/prometheus/common v0.62.0
 	github.com/prometheus/prometheus v0.55.1-0.20241102120812-a6fd22b9d2c8
 	github.com/stretchr/testify v1.10.0
 	github.com/thanos-io/thanos v0.37.2
@@ -73,7 +74,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.60.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.12.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -94,7 +94,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
+	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
@@ -102,7 +102,7 @@ require (
 	google.golang.org/api v0.195.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.66.0 // indirect
-	google.golang.org/protobuf v1.35.1 // indirect
+	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.31.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
-github.com/prometheus/common v0.60.0 h1:+V9PAREWNvJMAuJ1x1BaWl9dewMW4YrHZQbx0sJNllA=
-github.com/prometheus/common v0.60.0/go.mod h1:h0LYf1R1deLSKtD4Vdg8gy4RuOvENW2J/h19V5NADQw=
+github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
+github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdDeppTwGX4=
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/exporter-toolkit v0.12.0 h1:DkE5RcEZR3lQA2QD5JLVQIf41dFKNsVMXFhgqcif7fo=
@@ -604,8 +604,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
+golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -821,8 +821,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
-google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.1 h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=
+google.golang.org/protobuf v1.36.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This adds support for several HTTP client config options to the actual scraping, including basic auth, TLS configs, oauth support, custom header support, and proxy support.

The file is a YAML file in the same format as an `http_config` option block in a Prometheus scrape config:

https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config

This is not by coincidence; these are the same HTTP client config options that Prometheus exposes when configuring scrape jobs. For maximum compatibility, this change adopts the exact same format for the config, as well as uses the same underlying Prometheus libraries to load, parse, validate, and set the client options.

Quick demo/test, enabling basic auth on Prometheus itself:

```bash
~/go/src/github.com/prometheus/prometheus (main [  ]) -> cat http_basic_auth.yml
basic_auth_users:
  foo: $2y$10$fOnQwHmvgzLsyYby51ObT.fh8ZJwC7NaagrakTbztwtv/0jep9kXy

~/go/src/github.com/prometheus/prometheus (main [  ]) -> ./prometheus --config.file ./prometheus.yml --web.config.file http_basic_auth.yml
time=2025-02-19T03:47:17.465Z level=INFO source=main.go:640 msg="No time or size retention was set so using the default time retention" duration=15d
time=2025-02-19T03:47:17.465Z level=INFO source=main.go:687 msg="Starting Prometheus Server" mode=server version="(version=3.1.0, branch=main, revision=e04913aea2792a5c8bc7b3130c389ca1b027dd9b)"
time=2025-02-19T03:47:17.465Z level=INFO source=main.go:692 msg="operational information" build_context="(go=go1.24.0, platform=linux/amd64, user=tjhop@contraband, date=20250218-04:12:51, tags=netgo,builtinassets,stringlabels)" host_details="(Linux 6.13.2-arch1-1 #1 SMP PREEMPT_DYNAMIC Sat, 08 Feb 2025 18:54:55 +0000 x86_64 contraband (none))" fd_limits="(soft=524287, hard=524288)" vm_limits="(soft=unlimited, hard=unlimited)"
time=2025-02-19T03:47:17.465Z level=INFO source=main.go:768 msg="Leaving GOMAXPROCS=16: CPU quota undefined" component=automaxprocs
time=2025-02-19T03:47:17.467Z level=INFO source=web.go:654 msg="Start listening for connections" component=web address=0.0.0.0:9090
time=2025-02-19T03:47:17.467Z level=INFO source=main.go:1228 msg="Starting TSDB ..."
...
```

Build and run analyzer:
```bash
~/go/src/github.com/pedro-stanaka/prom-scrape-analyzer (feat/allow-http-client-configs [ U ]) -> cat http-config.yml
basic_auth:
  username: foo
  password: bar
~/go/src/github.com/pedro-stanaka/prom-scrape-analyzer (feat/allow-http-client-configs [ U ]) -> ./prom-scrape-analyzer-linux-amd64 cardinality --scrape-url http://localhost:9090/metrics --http.config http-config.yml
...
```