### PR TITLE
feat: add `--scrape.file` flag to scrape metrics from local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ for creating an intuitive and interactive command-line interface.
 - [x] Allow to select a specific metric to inspect, and show its series.
 - [x] Metric search with fuzzy search.
 - [x] [HTTP configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config) to support custom HTTP client options like basic auth, custom headers, proxy configs, etc.
+- [x] Support reading metrics from local files, to help analyze metrics that have already been collected.
 
 ## Planned Features
 

--- a/cmd/cardinality.go
+++ b/cmd/cardinality.go
@@ -402,7 +402,8 @@ func registerCardinalityCommand(app *extkingpin.App) {
 		httpConfigFile := opts.HttpConfigFile
 
 		if scrapeURL == "" && scrapeFile == "" {
-			return errors.New("No URL or file provided to scrape metrics. Please supply a target to scrape via `--scrape.url` or `--scrape.file` flags.")
+			return errors.New("No URL or file provided to scrape metrics. " +
+				"Please supply a target to scrape via `--scrape.url` or `--scrape.file` flags.")
 		}
 
 		if scrapeURL != "" && scrapeFile != "" {

--- a/cmd/cardinality.go
+++ b/cmd/cardinality.go
@@ -397,8 +397,17 @@ func registerCardinalityCommand(app *extkingpin.App) {
 		_ bool,
 	) error {
 		scrapeURL := opts.ScrapeURL
+		scrapeFile := opts.ScrapeFile
 		timeoutDuration := opts.Timeout
 		httpConfigFile := opts.HttpConfigFile
+
+		if scrapeURL == "" && scrapeFile == "" {
+			return errors.New("No URL or file provided to scrape metrics. Please supply a target to scrape via `--scrape.url` or `--scrape.file` flags.")
+		}
+
+		if scrapeURL != "" && scrapeFile != "" {
+			return errors.New("The flags `--scrape.url` and `--scrape.file` are mutually exclusive.")
+		}
 
 		metricTable := newModel(nil, opts.OutputHeight, logger)
 		p := tea.NewProgram(metricTable)
@@ -424,7 +433,8 @@ func registerCardinalityCommand(app *extkingpin.App) {
 
 			level.Info(logger).Log(
 				"msg", "scraping",
-				"url", scrapeURL,
+				"scrape_url", scrapeURL,
+				"scrape_file", scrapeFile,
 				"timeout", timeoutDuration,
 				"max_size", maxSize,
 				"http_config_file", httpConfigFile,
@@ -433,6 +443,7 @@ func registerCardinalityCommand(app *extkingpin.App) {
 			t0 := time.Now()
 			scraper := scrape.NewPromScraper(
 				scrapeURL,
+				scrapeFile,
 				logger,
 				scrape.WithTimeout(timeoutDuration),
 				scrape.WithMaxBodySize(maxSize),

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -10,6 +10,7 @@ import (
 
 type Options struct {
 	ScrapeURL      string
+	ScrapeFile     string
 	OutputHeight   int
 	MaxScrapeSize  string
 	Timeout        time.Duration
@@ -26,8 +27,12 @@ func (o *Options) MaxScrapeSizeBytes() (int64, error) {
 
 func (o *Options) AddFlags(app extkingpin.AppClause) {
 	app.Flag("scrape-url", "URL to scrape metrics from").
-		Required().
+		Default("").
 		StringVar(&o.ScrapeURL)
+
+	app.Flag("scrape-file", "File to scrape metrics from").
+		Default("").
+		StringVar(&o.ScrapeFile)
 
 	app.Flag("timeout", "Timeout for the scrape request").
 		Default("10s").

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -26,11 +26,11 @@ func (o *Options) MaxScrapeSizeBytes() (int64, error) {
 }
 
 func (o *Options) AddFlags(app extkingpin.AppClause) {
-	app.Flag("scrape-url", "URL to scrape metrics from").
+	app.Flag("scrape.url", "URL to scrape metrics from").
 		Default("").
 		StringVar(&o.ScrapeURL)
 
-	app.Flag("scrape-file", "File to scrape metrics from").
+	app.Flag("scrape.file", "File to scrape metrics from").
 		Default("").
 		StringVar(&o.ScrapeFile)
 


### PR DESCRIPTION
Resolves: #21

It's a common workflow to `curl` a metrics endpoint and save the metrics
output to a local file for further inspection. This expands PSA to
support scraping metrics from local files.

User facing changes include:
- New flag `--scrape.file` to specify the file to scrape from, as a
  counterpart to `--scrape.url`
- The flags are mutually exclusive, which required making the
  `--scrape.url` flag _not_ required, and leaving them both as optional.
To account for this, checks are introduced to ensure that 1-and-only-1
flag is set.

Internal changes include:
- `NewPromScraper()` accepts another arg for the string of the scrape
  file
- `PromScraper.Scrape()` now becomes a wrapper methods that calls
  `ScrapeFile()` or `ScrapeHTTP()` methods as appropriate for the
configs provided.

Notes:
- If this project ever introduces some type of "watch" mechanism for
  over-time analysis, we'll now need a solution for both HTTP and file
watches, which is obviously extra complexity.

Validation:
```bash
curl -s localhost:9100/metrics > /tmp/node_exporter.metrics
./prom-scrape-analyzer-linux-amd64 cardinality --scrape-file /tmp/node_exporter.metrics
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
